### PR TITLE
[FEAT] 스토어 카카오 오픈채팅 링크 조회 구현 - #25

### DIFF
--- a/cakey-api/src/main/java/com/cakey/store/controller/StoreController.java
+++ b/cakey-api/src/main/java/com/cakey/store/controller/StoreController.java
@@ -74,4 +74,10 @@ public class StoreController {
                 SuccessCode.OK,
                 storeService.getAllStation());
     }
+
+    @GetMapping("/{storeId}/kakaoLink")
+    public ResponseEntity<BaseResponse<?>> getKakaoLink(@PathVariable("storeId") final Long storeId) {
+        return ApiResponseUtil.success(SuccessCode.OK,
+                storeService.getStoreKakaoLink(storeId));
+    }
 }

--- a/cakey-api/src/main/java/com/cakey/store/dto/StoreKakaoLinkRes.java
+++ b/cakey-api/src/main/java/com/cakey/store/dto/StoreKakaoLinkRes.java
@@ -1,0 +1,9 @@
+package com.cakey.store.dto;
+
+public record StoreKakaoLinkRes(
+        String kakaoLink
+) {
+    public static StoreKakaoLinkRes from(String kakaoLink) {
+        return new StoreKakaoLinkRes(kakaoLink);
+    }
+}

--- a/cakey-api/src/main/java/com/cakey/store/service/StoreService.java
+++ b/cakey-api/src/main/java/com/cakey/store/service/StoreService.java
@@ -2,9 +2,12 @@ package com.cakey.store.service;
 
 import com.cakey.cake.dto.CakeMainImageDto;
 import com.cakey.cake.facade.CakeFacade;
+import com.cakey.common.exception.NotFoundException;
 import com.cakey.store.domain.Station;
 import com.cakey.store.dto.*;
 import com.cakey.store.facade.StoreFacade;
+import com.cakey.user.dto.UserInfoDto;
+import com.cakey.user.dto.UserInfoRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -131,5 +134,16 @@ public class StoreService {
                     );
                 })
                 .toList();
+    }
+
+    public StoreKakaoLinkRes getStoreKakaoLink(final Long storeId) {
+        final StoreKakaoLinkDto storeKakaoLinkDto;
+        try {
+            storeKakaoLinkDto = storeFacade.findById(storeId);
+        } catch (NotFoundException e) {
+            //todo: 추후 구체적인 예외처리
+            throw e;
+        }
+        return new StoreKakaoLinkRes(storeKakaoLinkDto.kakaoLink());
     }
 }

--- a/cakey-domain/src/main/java/com/cakey/store/dto/StoreKakaoLinkDto.java
+++ b/cakey-domain/src/main/java/com/cakey/store/dto/StoreKakaoLinkDto.java
@@ -1,0 +1,9 @@
+package com.cakey.store.dto;
+
+public record StoreKakaoLinkDto(
+        String kakaoLink
+) {
+    public StoreKakaoLinkDto(String kakaoLink) {
+        this.kakaoLink = kakaoLink;
+    }
+}

--- a/cakey-domain/src/main/java/com/cakey/store/facade/StoreFacade.java
+++ b/cakey-domain/src/main/java/com/cakey/store/facade/StoreFacade.java
@@ -1,8 +1,10 @@
 package com.cakey.store.facade;
 
 import com.cakey.store.domain.Station;
+import com.cakey.store.domain.Store;
 import com.cakey.store.dto.StoreCoordianteDto;
 import com.cakey.store.dto.StoreInfoDto;
+import com.cakey.store.dto.StoreKakaoLinkDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -63,9 +65,14 @@ public class StoreFacade {
         return storeRetriever.countStoresByStation(station);
     }
 
-    //마지막 스토어아이디 계싼
+    //마지막 스토어아이디 계산
     public Long calculateLastStoreId(final List<StoreInfoDto> storeInfoDtos) {
         return storeInfoDtos.isEmpty() ? null : storeInfoDtos.get(storeInfoDtos.size() - 1).getStoreId();
     }
 
+    //카카오 링크
+    public StoreKakaoLinkDto findById(final Long storeId) {
+        Store store = storeRetriever.findById(storeId);
+        return new StoreKakaoLinkDto(store.getOpenKakaoUrl());
+    }
 }

--- a/cakey-domain/src/main/java/com/cakey/store/facade/StoreRetriever.java
+++ b/cakey-domain/src/main/java/com/cakey/store/facade/StoreRetriever.java
@@ -1,9 +1,13 @@
 package com.cakey.store.facade;
 
+import com.cakey.common.exception.NotFoundException;
 import com.cakey.store.domain.Station;
+import com.cakey.store.domain.Store;
 import com.cakey.store.dto.StoreCoordianteDto;
 import com.cakey.store.dto.StoreInfoDto;
+import com.cakey.store.dto.StoreKakaoLinkDto;
 import com.cakey.store.repository.StoreRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -48,5 +52,11 @@ public class StoreRetriever {
 
     public int countStoresByStation(final Station station) {
         return storeRepository.countStoresByStation(station);
+    }
+
+    public Store findById(final Long storeId) {
+        return storeRepository.findById(storeId)
+                .orElseThrow(() -> new NotFoundException());
+
     }
 }

--- a/cakey-domain/src/main/java/com/cakey/store/repository/StoreRepository.java
+++ b/cakey-domain/src/main/java/com/cakey/store/repository/StoreRepository.java
@@ -2,6 +2,7 @@ package com.cakey.store.repository;
 
 import com.cakey.store.domain.Station;
 import com.cakey.store.domain.Store;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +17,6 @@ public interface StoreRepository extends JpaRepository<Store, Long>, StoreReposi
     // 특정 지하철역의 스토어 개수
     @Query("SELECT COUNT(s) FROM Store s WHERE s.station = :stationName")
     int countStoresByStation(Station stationName);
+
+    Optional<Store> findById(Long storeId);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #25

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 스토어의 카카오 오픈채팅 링크를 조회합니다.
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 추후 querydsl 적용할것...
<img width="623" alt="스크린샷 2025-01-15 오후 10 08 34" src="https://github.com/user-attachments/assets/9f6b5e0a-5e71-4e4c-b31f-5f7e86b2bbe5" />
